### PR TITLE
Fix remove_tracks: use correct payload key for DELETE /items

### DIFF
--- a/src/spotify_mcp/server.py
+++ b/src/spotify_mcp/server.py
@@ -489,7 +489,7 @@ async def spotify_playlist(
                     {"uri": f"spotify:track:{t}" if not t.startswith("spotify:") else t}
                     for t in track_ids
                 ]
-                await _delete(f"playlists/{playlist_id}/items", {"tracks": uris})
+                await _delete(f"playlists/{playlist_id}/items", {"items": uris})
                 return f"Removed {len(uris)} track(s) from playlist."
 
             case "change_details":


### PR DESCRIPTION
## Summary
- The `remove_tracks` action sends `{"tracks": [...]}` as the payload to `DELETE /playlists/{id}/items`, but the Spotify API expects the key `"items"`, not `"tracks"`
- This causes a `400 Bad Request: No uris provided` error on every `remove_tracks` call
- One-line fix: change `{"tracks": uris}` to `{"items": uris}` on line 492

## Verified
Tested against the Spotify Web API with curl:
- `DELETE /items` + `{"items": [{"uri": ...}]}` → **200 OK**
- `DELETE /items` + `{"tracks": [{"uri": ...}]}` → **400 "No uris provided"**

Note: the older `DELETE /playlists/{id}/tracks` endpoint with `{"tracks": [...]}` now returns **403 Forbidden** (deprecated).