### PR TITLE
fix: handle non-JSON responses from playback endpoints

### DIFF
--- a/src/spotify_mcp/server.py
+++ b/src/spotify_mcp/server.py
@@ -132,7 +132,10 @@ async def _api(method: str, path: str, **kwargs) -> Optional[dict]:
     resp.raise_for_status()
     if resp.status_code == 204 or not resp.content:
         return None
-    return resp.json()
+    try:
+        return resp.json()
+    except (json.JSONDecodeError, ValueError):
+        return None
 
 
 async def _get(path: str, **params) -> Optional[dict]:


### PR DESCRIPTION
## Summary
- Wraps `resp.json()` in `_api()` with a `try/except (json.JSONDecodeError, ValueError)` to return `None` instead of raising when Spotify returns a successful response with a non-JSON body
- Playback commands (play, pause, skip) now return their success messages instead of a misleading `Error: Expecting value: line 1 column 1 (char 0)`

Fixes #3

## Test plan
- [ ] Call `spotify_playback` with action `pause` — should return "Playback paused." without error
- [ ] Call `spotify_playback` with action `start` — should return "Playback started." without error
- [ ] Call `spotify_playback` with action `skip` — should return "Skipped 1 track(s)." without error
- [ ] Call `spotify_playback` with action `get` — should still return track info as JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)