### PR TITLE
feat: add 'previous' action to spotify_playback

### DIFF
--- a/src/spotify_mcp/server.py
+++ b/src/spotify_mcp/server.py
@@ -278,14 +278,14 @@ async def _ensure_device() -> Optional[str]:
 # ── Tools ────────────────────────────────────────────────────────────────────
 @mcp.tool()
 async def spotify_playback(
-    action: str = Field(description="Action: 'get', 'start', 'pause', or 'skip'"),
+    action: str = Field(description="Action: 'get', 'start', 'pause', 'skip', or 'previous'"),
     spotify_uri: Optional[str] = Field(
         default=None,
         description="Spotify URI to play (e.g. spotify:track:xxx). For 'start' action.",
     ),
     num_skips: int = Field(default=1, description="Number of tracks to skip (for 'skip' action)"),
 ) -> str:
-    """Control Spotify playback - get current track, start/pause playback, or skip tracks."""
+    """Control Spotify playback - get current track, start/pause playback, skip, or go to previous track."""
     try:
         match action:
             case "get":
@@ -320,6 +320,10 @@ async def spotify_playback(
                 for _ in range(num_skips):
                     await _post("me/player/next")
                 return f"Skipped {num_skips} track(s)."
+
+            case "previous":
+                await _post("me/player/previous")
+                return "Skipped to previous track."
 
             case _:
                 return f"Unknown action: {action}"


### PR DESCRIPTION
## Summary
- Adds `previous` action to `spotify_playback` tool using `POST /me/player/previous`
- Updates tool description and docstring to include the new action

Fixes #5

## Test plan
- [ ] Call `spotify_playback` with action `previous` — should return "Skipped to previous track." and music goes back
- [ ] Verify existing actions (`get`, `start`, `pause`, `skip`) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)