### PR TITLE
feat: add spotify_recently_played tool

### DIFF
--- a/src/spotify_mcp/server.py
+++ b/src/spotify_mcp/server.py
@@ -52,6 +52,7 @@ SCOPES = " ".join([
     "user-read-playback-state",
     "user-modify-playback-state",
     "user-read-currently-playing",
+    "user-read-recently-played",
     "playlist-read-private",
     "playlist-read-collaborative",
     "playlist-modify-private",
@@ -586,6 +587,27 @@ async def spotify_liked_songs(
             for t in tracks:
                 t.pop("artist_ids", None)
 
+        return json.dumps({"total": len(tracks), "tracks": tracks}, indent=2)
+    except Exception as e:
+        return _handle_error(e)
+
+
+@mcp.tool()
+async def spotify_recently_played(
+    limit: int = Field(default=10, description="Number of recently played tracks to return (max 50)"),
+) -> str:
+    """Get the user's recently played tracks with timestamps."""
+    try:
+        limit = max(1, min(50, limit))
+        data = await _get("me/player/recently-played", limit=limit)
+        if not data or not data.get("items"):
+            return "No recently played tracks found."
+        tracks = []
+        for item in data["items"]:
+            track = _parse_track(item.get("track"))
+            if track:
+                track["played_at"] = item.get("played_at")
+                tracks.append(track)
         return json.dumps({"total": len(tracks), "tracks": tracks}, indent=2)
     except Exception as e:
         return _handle_error(e)


### PR DESCRIPTION
## Summary
- Adds new `spotify_recently_played` tool to retrieve listening history with timestamps
- Uses `GET /me/player/recently-played` endpoint (limit 1-50, default 10)
- Adds `user-read-recently-played` scope to SCOPES constant

Fixes #8

## Test plan
- [ ] Call `spotify_recently_played` with default limit — should return last 10 tracks with `played_at` timestamps
- [ ] Call with `limit: 5` — should return 5 tracks
- [ ] Verify existing tools still work (scope addition is additive)

**Note:** Users will need to re-run `spotify-mcp --auth` to grant the new scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)